### PR TITLE
Add per-window brightness monitoring

### DIFF
--- a/NegativeScreen/NativeMethods.cs
+++ b/NegativeScreen/NativeMethods.cs
@@ -129,9 +129,16 @@ namespace NegativeScreen
 		/// <param name="rect"></param>
 		/// <param name="erase"></param>
 		/// <returns></returns>
-		[DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
-		[return: MarshalAs(UnmanagedType.Bool)]
-		public static extern bool InvalidateRect(IntPtr hWnd, IntPtr rect, [MarshalAs(UnmanagedType.Bool)] bool erase);
+                [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
+                [return: MarshalAs(UnmanagedType.Bool)]
+                public static extern bool InvalidateRect(IntPtr hWnd, IntPtr rect, [MarshalAs(UnmanagedType.Bool)] bool erase);
+
+                [DllImport("user32.dll", SetLastError = true)]
+                [return: MarshalAs(UnmanagedType.Bool)]
+                public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+                [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+                public static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
 
 		/// <summary>
 		/// </summary>

--- a/NegativeScreen/NegativeScreen.csproj
+++ b/NegativeScreen/NegativeScreen.csproj
@@ -101,6 +101,8 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Program.cs" />
+    <Compile Include="WindowOverlay.cs" />
+    <Compile Include="WindowBrightnessWatcher.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="OverlayManager.cs">
       <SubType>Form</SubType>

--- a/NegativeScreen/OverlayManager.cs
+++ b/NegativeScreen/OverlayManager.cs
@@ -22,6 +22,7 @@ using System.Text;
 using System.Windows.Forms;
 using System.Runtime.InteropServices;
 using System.Drawing;
+using System.Threading;
 
 namespace NegativeScreen
 {
@@ -65,7 +66,12 @@ namespace NegativeScreen
 		private bool resolutionHasChanged = false;
 
 		private NotifyIcon notifyIcon;
-		private ContextMenuStrip contextMenu;
+                private ContextMenuStrip contextMenu;
+
+                private WindowOverlay windowOverlay;
+                private Timer brightnessTimer;
+                private IntPtr monitoredWindow = IntPtr.Zero;
+                private const float BRIGHTNESS_THRESHOLD = 0.8f;
         
         private void CycleMonitors()
         {
@@ -425,6 +431,32 @@ namespace NegativeScreen
             notifyIcon.Dispose();
             this.Dispose();
             Application.Exit();
+        }
+
+        public void StartWindowMonitor(IntPtr hwnd)
+        {
+            monitoredWindow = hwnd;
+            brightnessTimer = new Timer(CheckWindowBrightness, null, 0, 1000);
+        }
+
+        private void CheckWindowBrightness(object state)
+        {
+            float brightness = WindowBrightnessWatcher.GetAverageBrightness(monitoredWindow);
+            if (brightness > BRIGHTNESS_THRESHOLD)
+            {
+                if (windowOverlay == null)
+                {
+                    windowOverlay = new WindowOverlay(monitoredWindow);
+                }
+            }
+            else
+            {
+                if (windowOverlay != null)
+                {
+                    windowOverlay.Dispose();
+                    windowOverlay = null;
+                }
+            }
         }
 
 	}

--- a/NegativeScreen/Program.cs
+++ b/NegativeScreen/Program.cs
@@ -53,9 +53,18 @@ To avoid known bugs relative to the used APIs, please instead run the 64 bits co
 			//without this call, and with custom DPI settings,
 			//the magnified window is either partially out of the screen,
 			//or blurry, if the transformation scale is forced to 1.
-			NativeMethods.SetProcessDPIAware();
-			OverlayManager manager = new OverlayManager();
-		}
+                        NativeMethods.SetProcessDPIAware();
+                        OverlayManager manager = new OverlayManager();
+
+                        if (args.Length > 0)
+                        {
+                                IntPtr hwnd = NativeMethods.FindWindow(null, args[0]);
+                                if (hwnd != IntPtr.Zero)
+                                {
+                                        manager.StartWindowMonitor(hwnd);
+                                }
+                        }
+                }
 
 		private static bool IsAnotherInstanceAlreadyRunning()
 		{

--- a/NegativeScreen/WindowBrightnessWatcher.cs
+++ b/NegativeScreen/WindowBrightnessWatcher.cs
@@ -1,0 +1,63 @@
+//Copyright 2011-2012 Melvyn Laily
+//http://arcanesanctum.net
+
+//This file is part of NegativeScreen.
+
+//This program is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+
+//This program is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+
+//You should have received a copy of the GNU General Public License
+//along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Drawing;
+
+namespace NegativeScreen
+{
+    /// <summary>
+    /// Provides brightness measurement for a specific window.
+    /// </summary>
+    internal static class WindowBrightnessWatcher
+    {
+        /// <summary>
+        /// Returns the average brightness of the specified window as a value between 0 and 1.
+        /// </summary>
+        public static float GetAverageBrightness(IntPtr hwnd)
+        {
+            RECT rect;
+            if (!NativeMethods.GetWindowRect(hwnd, out rect))
+            {
+                return 0f;
+            }
+            int width = rect.right - rect.left;
+            int height = rect.bottom - rect.top;
+            if (width <= 0 || height <= 0)
+            {
+                return 0f;
+            }
+
+            using (Bitmap bmp = new Bitmap(width, height))
+            using (Graphics g = Graphics.FromImage(bmp))
+            {
+                g.CopyFromScreen(rect.left, rect.top, 0, 0, new Size(width, height));
+                long sum = 0;
+                for (int x = 0; x < width; x++)
+                {
+                    for (int y = 0; y < height; y++)
+                    {
+                        Color c = bmp.GetPixel(x, y);
+                        sum += c.R + c.G + c.B;
+                    }
+                }
+                return sum / (3f * width * height * 255f);
+            }
+        }
+    }
+}

--- a/NegativeScreen/WindowOverlay.cs
+++ b/NegativeScreen/WindowOverlay.cs
@@ -1,0 +1,101 @@
+//Copyright 2011-2012 Melvyn Laily
+//http://arcanesanctum.net
+
+//This file is part of NegativeScreen.
+
+//This program is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+
+//This program is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+
+//You should have received a copy of the GNU General Public License
+//along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using System.Runtime.InteropServices;
+
+namespace NegativeScreen
+{
+    /// <summary>
+    /// Overlay that inverts colours of a single window.
+    /// </summary>
+    public class WindowOverlay : Form
+    {
+        private IntPtr hwndMag;
+        private IntPtr targetWindow;
+        /// <summary>
+        /// used when refreshing the control
+        /// </summary>
+        public IntPtr HwndMag { get { return hwndMag; } }
+
+        public WindowOverlay(IntPtr hwnd)
+            : base()
+        {
+            targetWindow = hwnd;
+            RECT rect;
+            if (!NativeMethods.GetWindowRect(hwnd, out rect))
+            {
+                throw new Exception("GetWindowRect()", NativeMethods.GetExceptionForLastError());
+            }
+
+            this.StartPosition = FormStartPosition.Manual;
+            this.Location = new Point(rect.left, rect.top);
+            this.Size = new Size(rect.right - rect.left, rect.bottom - rect.top);
+            this.TopMost = true;
+            this.FormBorderStyle = FormBorderStyle.None;
+            this.WindowState = FormWindowState.Normal;
+            this.ShowInTaskbar = false;
+
+            IntPtr hInst = NativeMethods.GetModuleHandle(null);
+            if (hInst == IntPtr.Zero)
+            {
+                throw new Exception("GetModuleHandle()", NativeMethods.GetExceptionForLastError());
+            }
+
+            if (NativeMethods.SetWindowLong(this.Handle, NativeMethods.GWL_EXSTYLE, (int)ExtendedWindowStyles.WS_EX_LAYERED | (int)ExtendedWindowStyles.WS_EX_TRANSPARENT) == 0)
+            {
+                throw new Exception("SetWindowLong()", NativeMethods.GetExceptionForLastError());
+            }
+
+            if (!NativeMethods.SetLayeredWindowAttributes(this.Handle, 0, 255, LayeredWindowAttributeFlags.LWA_ALPHA))
+            {
+                throw new Exception("SetLayeredWindowAttributes()", NativeMethods.GetExceptionForLastError());
+            }
+
+            hwndMag = NativeMethods.CreateWindowEx(0,
+                    NativeMethods.WC_MAGNIFIER,
+                    "MagnifierWindow",
+                    (int)WindowStyles.WS_CHILD |
+                    (int)WindowStyles.WS_VISIBLE,
+                    0, 0, this.Width, this.Height,
+                    this.Handle, IntPtr.Zero, hInst, IntPtr.Zero);
+
+            if (hwndMag == IntPtr.Zero)
+            {
+                throw new Exception("CreateWindowEx()", NativeMethods.GetExceptionForLastError());
+            }
+
+            BuiltinMatrices.ChangeColorEffect(hwndMag, BuiltinMatrices.Negative);
+
+            if (!NativeMethods.MagSetWindowSource(this.hwndMag, rect))
+            {
+                throw new Exception("MagSetWindowSource()", NativeMethods.GetExceptionForLastError());
+            }
+
+            Transformation transformation = new Transformation(1.0f);
+            if (!NativeMethods.MagSetWindowTransform(this.hwndMag, ref transformation))
+            {
+                throw new Exception("MagSetWindowTransform()", NativeMethods.GetExceptionForLastError());
+            }
+
+            this.Show();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Win32 wrappers for `GetWindowRect` and `FindWindow`
- support brightness-based inversion for specific windows
- monitor windows with `WindowBrightnessWatcher`
- overlay a targeted window using `WindowOverlay`
- build updates to include new classes

## Testing
- `msbuild NegativeScreen.sln /t:Build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610dc13c1083279b2703b0beab728c